### PR TITLE
Add realtime export activity log and asynchronous results

### DIFF
--- a/real-media-export/assets/css/admin.css
+++ b/real-media-export/assets/css/admin.css
@@ -1,0 +1,272 @@
+.real-media-export-panels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    align-items: flex-start;
+    margin-top: 24px;
+}
+
+.real-media-export-panel {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(31, 41, 55, 0.05);
+    padding: 24px;
+    flex: 1 1 360px;
+}
+
+.real-media-export-panel--form {
+    max-width: 420px;
+}
+
+.real-media-export-form .form-table th {
+    width: 200px;
+}
+
+.real-media-export-form .form-table td .description {
+    margin-top: 4px;
+}
+
+.real-media-export-panel--activity {
+    flex: 1 1 520px;
+}
+
+.real-media-export-activity {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.real-media-export-log {
+    background: #f6f7f7;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    padding: 16px;
+    min-height: 140px;
+    max-height: 260px;
+    overflow-y: auto;
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.real-media-export-log__placeholder {
+    margin: 0;
+    color: #6c7781;
+}
+
+.real-media-export-log__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.real-media-export-log__item {
+    display: flex;
+    gap: 12px;
+    align-items: baseline;
+    margin-bottom: 12px;
+    opacity: 0;
+    transform: translateY(8px);
+    animation: rmeFadeInUp 0.35s ease forwards;
+}
+
+.real-media-export-log__item:last-child {
+    margin-bottom: 0;
+}
+
+.real-media-export-log__time {
+    font-family: "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 12px;
+    color: #50575e;
+    min-width: 68px;
+}
+
+.real-media-export-log__message {
+    flex: 1;
+    color: #1d2327;
+}
+
+.real-media-export-log__item.is-error .real-media-export-log__message {
+    color: #b32d2e;
+}
+
+.real-media-export-log__item.is-warning .real-media-export-log__message {
+    color: #d98500;
+}
+
+.real-media-export-message .notice {
+    margin: 0;
+}
+
+.real-media-export-results {
+    border: 1px solid #dcdcde;
+    border-radius: 10px;
+    padding: 20px;
+    background: linear-gradient(180deg, #ffffff 0%, #f8f9fa 100%);
+}
+
+.real-media-export-results__header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    align-items: center;
+    margin-bottom: 16px;
+    font-size: 13px;
+    color: #50575e;
+}
+
+.real-media-export-results__summary {
+    font-weight: 500;
+}
+
+.real-media-export-results__placeholder {
+    margin: 0;
+    color: #6c7781;
+    font-style: italic;
+}
+
+.real-media-export-results__grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.real-media-export-card {
+    position: relative;
+    padding: 22px;
+    border-radius: 12px;
+    border: 1px solid rgba(17, 24, 39, 0.08);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, #ffffff 30%, #f3f4f6 100%);
+    box-shadow: 0 18px 35px -20px rgba(15, 23, 42, 0.35);
+    opacity: 0;
+    transform: translateY(16px);
+    animation: rmeCardEnter 0.45s ease forwards;
+    animation-delay: calc(var(--real-media-export-card-index, 0) * 0.1s);
+}
+
+.real-media-export-card__header {
+    margin-bottom: 16px;
+}
+
+.real-media-export-card__title {
+    margin: 0 0 4px;
+    font-size: 16px;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.real-media-export-card__subtitle {
+    margin: 0;
+    font-size: 13px;
+    color: #64748b;
+}
+
+.real-media-export-card__meta {
+    list-style: none;
+    margin: 0 0 12px;
+    padding: 0;
+    display: grid;
+    gap: 8px;
+}
+
+.real-media-export-card__meta-label {
+    display: block;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #6c7781;
+}
+
+.real-media-export-card__meta-value {
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.real-media-export-card__detail {
+    margin: 0 0 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.real-media-export-card__detail-label {
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #6c7781;
+}
+
+.real-media-export-card__detail-value {
+    font-size: 13px;
+    color: #1d2327;
+    word-break: break-word;
+}
+
+.real-media-export-card__note {
+    margin: 8px 0 0;
+    font-size: 12px;
+    color: #9d6700;
+}
+
+.real-media-export-card__actions {
+    margin-top: 16px;
+}
+
+.real-media-export-loading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: #50575e;
+}
+
+.real-media-export-loading::before {
+    content: "";
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid #2271b1;
+    border-top-color: transparent;
+    animation: rmeSpin 0.8s linear infinite;
+}
+
+@keyframes rmeFadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes rmeCardEnter {
+    from {
+        opacity: 0;
+        transform: translateY(18px) scale(0.98);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes rmeSpin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 960px) {
+    .real-media-export-panel {
+        flex: 1 1 100%;
+    }
+
+    .real-media-export-panel--form {
+        max-width: none;
+    }
+}

--- a/real-media-export/assets/js/admin.js
+++ b/real-media-export/assets/js/admin.js
@@ -1,0 +1,379 @@
+(function () {
+    const settings = window.realMediaExportSettings || {};
+    const form = document.getElementById('real-media-export-form');
+    const logContainer = document.getElementById('real-media-export-log');
+    const resultsContainer = document.getElementById('real-media-export-results');
+    const messageContainer = document.getElementById('real-media-export-message');
+    let isProcessing = false;
+
+    const getString = (key, fallback) => {
+        if (settings && settings.i18n && Object.prototype.hasOwnProperty.call(settings.i18n, key)) {
+            return settings.i18n[key];
+        }
+        return fallback;
+    };
+
+    const formatTemplate = (template, values) => {
+        if (typeof template !== 'string') {
+            return '';
+        }
+        const positional = Array.isArray(values) ? values : [];
+        const queue = positional.slice();
+        return template.replace(/%(\d+)\$s|%s/g, (match, index) => {
+            if (index) {
+                const i = parseInt(index, 10) - 1;
+                return typeof positional[i] !== 'undefined' ? positional[i] : '';
+            }
+            return queue.length ? queue.shift() : '';
+        });
+    };
+
+    const formatNumber = (value) => {
+        try {
+            return new Intl.NumberFormat(window.navigator.language || undefined).format(value);
+        } catch (err) {
+            return String(value);
+        }
+    };
+
+    const statusToNoticeClass = (status) => {
+        if ('success' === status) {
+            return 'notice notice-success';
+        }
+        if ('warning' === status) {
+            return 'notice notice-warning';
+        }
+        if ('error' === status) {
+            return 'notice notice-error';
+        }
+        return 'notice';
+    };
+
+    const ensureLogList = () => {
+        if (!logContainer) {
+            return null;
+        }
+        let list = logContainer.querySelector('.real-media-export-log__list');
+        if (!list) {
+            logContainer.innerHTML = '';
+            list = document.createElement('ul');
+            list.className = 'real-media-export-log__list';
+            logContainer.appendChild(list);
+        }
+        return list;
+    };
+
+    const clearLog = () => {
+        if (!logContainer) {
+            return;
+        }
+        logContainer.innerHTML = '';
+    };
+
+    const appendLog = (message, type = 'info') => {
+        if (!message || !logContainer) {
+            return;
+        }
+        const list = ensureLogList();
+        if (!list) {
+            return;
+        }
+        const item = document.createElement('li');
+        item.className = 'real-media-export-log__item is-' + type;
+
+        const time = document.createElement('span');
+        time.className = 'real-media-export-log__time';
+        time.textContent = new Date().toLocaleTimeString();
+
+        const text = document.createElement('span');
+        text.className = 'real-media-export-log__message';
+        text.textContent = message;
+
+        item.appendChild(time);
+        item.appendChild(text);
+        list.appendChild(item);
+        logContainer.scrollTo({ top: logContainer.scrollHeight, behavior: 'smooth' });
+    };
+
+    const setMessage = (payload) => {
+        if (!messageContainer) {
+            return;
+        }
+        const status = payload && payload.status ? payload.status : '';
+        messageContainer.setAttribute('data-status', status);
+        messageContainer.innerHTML = '';
+        const messageHtml = payload && payload.message_html ? payload.message_html : '';
+        const messageText = payload && payload.message_text ? payload.message_text : '';
+        const content = messageHtml || messageText;
+        if (!content) {
+            return;
+        }
+        const notice = document.createElement('div');
+        notice.className = statusToNoticeClass(status);
+        const inner = document.createElement('div');
+        inner.className = 'real-media-export-message__content';
+        if (messageHtml) {
+            inner.innerHTML = messageHtml;
+        } else {
+            inner.textContent = messageText;
+        }
+        notice.appendChild(inner);
+        messageContainer.appendChild(notice);
+    };
+
+    const setResultsLoading = () => {
+        if (!resultsContainer) {
+            return;
+        }
+        resultsContainer.innerHTML = '';
+        const loading = document.createElement('div');
+        loading.className = 'real-media-export-loading';
+        loading.textContent = getString('loading', 'Création des archives…');
+        resultsContainer.appendChild(loading);
+    };
+
+    const renderResults = (payload) => {
+        if (!resultsContainer) {
+            return;
+        }
+        resultsContainer.innerHTML = '';
+        const summary = payload && payload.summary ? payload.summary : null;
+        const archives = Array.isArray(payload && payload.archives) ? payload.archives : [];
+        const headerParts = [];
+
+        if (payload && payload.generated_at_formatted) {
+            const template = getString('generatedOn', 'Généré le %s');
+            const timestamp = document.createElement('span');
+            timestamp.className = 'real-media-export-results__timestamp';
+            timestamp.textContent = formatTemplate(template, [payload.generated_at_formatted]);
+            headerParts.push(timestamp);
+        }
+
+        if (summary) {
+            const parts = [];
+            if (summary.files_exported || summary.files_total) {
+                const template = getString('filesExportedSummary', '%1$s fichier(s) exporté(s) sur %2$s');
+                parts.push(
+                    formatTemplate(template, [
+                        formatNumber(summary.files_exported || 0),
+                        formatNumber(summary.files_total || 0),
+                    ])
+                );
+            }
+            const archiveCount = typeof summary.archives_count !== 'undefined' ? summary.archives_count : archives.length;
+            if (archiveCount) {
+                const template = getString('archivesCountSummary', '%s archive(s)');
+                parts.push(formatTemplate(template, [formatNumber(archiveCount)]));
+            }
+            if (summary.files_skipped) {
+                const template = getString('filesSkippedSummary', '%s fichier(s) ignoré(s)');
+                parts.push(formatTemplate(template, [formatNumber(summary.files_skipped)]));
+            }
+            if (parts.length) {
+                const info = document.createElement('span');
+                info.className = 'real-media-export-results__summary';
+                info.textContent = parts.join(' · ');
+                headerParts.push(info);
+            }
+        }
+
+        if (headerParts.length) {
+            const header = document.createElement('div');
+            header.className = 'real-media-export-results__header';
+            headerParts.forEach((part) => header.appendChild(part));
+            resultsContainer.appendChild(header);
+        }
+
+        if (!archives.length) {
+            const placeholder = document.createElement('p');
+            placeholder.className = 'real-media-export-results__placeholder';
+            placeholder.textContent = getString('resultsPlaceholder', 'Les liens de téléchargement apparaîtront ici une fois les archives prêtes.');
+            resultsContainer.appendChild(placeholder);
+            return;
+        }
+
+        const grid = document.createElement('div');
+        grid.className = 'real-media-export-results__grid';
+
+        archives.forEach((archive, index) => {
+            const card = document.createElement('article');
+            card.className = 'real-media-export-card';
+            card.style.setProperty('--real-media-export-card-index', String(index));
+
+            const header = document.createElement('header');
+            header.className = 'real-media-export-card__header';
+            const title = document.createElement('h3');
+            title.className = 'real-media-export-card__title';
+            title.textContent = archive && archive.file ? archive.file : getString('archiveTitleFallback', 'Archive ZIP');
+            header.appendChild(title);
+            if (archive && archive.created_at_formatted) {
+                const subtitle = document.createElement('p');
+                subtitle.className = 'real-media-export-card__subtitle';
+                subtitle.textContent = formatTemplate(getString('generatedOn', 'Généré le %s'), [archive.created_at_formatted]);
+                header.appendChild(subtitle);
+            }
+            card.appendChild(header);
+
+            const metaList = document.createElement('ul');
+            metaList.className = 'real-media-export-card__meta';
+            const metaEntries = [
+                { label: getString('compressedSizeLabel', 'Taille compressée'), value: archive && archive.size_human },
+                { label: getString('originalsSizeLabel', 'Taille cumulée des originaux'), value: archive && archive.bytes_total_human },
+                { label: getString('filesCountLabel', 'Nombre de fichiers'), value: archive && archive.file_count ? formatNumber(archive.file_count) : '' },
+            ];
+            metaEntries.forEach((entry) => {
+                if (!entry.value) {
+                    return;
+                }
+                const item = document.createElement('li');
+                const label = document.createElement('span');
+                label.className = 'real-media-export-card__meta-label';
+                label.textContent = entry.label;
+                const value = document.createElement('span');
+                value.className = 'real-media-export-card__meta-value';
+                value.textContent = entry.value;
+                item.appendChild(label);
+                item.appendChild(value);
+                metaList.appendChild(item);
+            });
+            card.appendChild(metaList);
+
+            const details = [
+                { label: getString('primaryFoldersLabel', 'Dossiers principaux'), value: archive && Array.isArray(archive.folders) ? archive.folders.join(', ') : '' },
+                { label: getString('previewFilesLabel', 'Exemples de fichiers'), value: archive && Array.isArray(archive.files_preview) ? archive.files_preview.join(', ') : '' },
+            ];
+            details.forEach((detail) => {
+                if (!detail.value) {
+                    return;
+                }
+                const paragraph = document.createElement('p');
+                paragraph.className = 'real-media-export-card__detail';
+                const detailLabel = document.createElement('span');
+                detailLabel.className = 'real-media-export-card__detail-label';
+                detailLabel.textContent = detail.label;
+                const detailValue = document.createElement('span');
+                detailValue.className = 'real-media-export-card__detail-value';
+                detailValue.textContent = detail.value;
+                paragraph.appendChild(detailLabel);
+                paragraph.appendChild(detailValue);
+                card.appendChild(paragraph);
+            });
+
+            if (archive && archive.max_size_reached) {
+                const note = document.createElement('p');
+                note.className = 'real-media-export-card__note';
+                note.textContent = getString('maxSizeReachedNote', 'Cet archive a été clôturée automatiquement car la taille maximale définie a été atteinte.');
+                card.appendChild(note);
+            }
+
+            if (archive && archive.download_url) {
+                const actions = document.createElement('div');
+                actions.className = 'real-media-export-card__actions';
+                const button = document.createElement('a');
+                button.className = 'button button-primary';
+                button.href = archive.download_url;
+                button.textContent = getString('downloadLabel', 'Télécharger');
+                actions.appendChild(button);
+                card.appendChild(actions);
+            } else {
+                const unavailable = document.createElement('p');
+                unavailable.className = 'real-media-export-card__note';
+                unavailable.textContent = getString('downloadUnavailable', 'Lien de téléchargement indisponible.');
+                card.appendChild(unavailable);
+            }
+
+            grid.appendChild(card);
+        });
+
+        resultsContainer.appendChild(grid);
+    };
+
+    const toggleProcessing = (active) => {
+        isProcessing = active;
+        if (!form) {
+            return;
+        }
+        const submit = form.querySelector('button[type="submit"], input[type="submit"]');
+        if (submit) {
+            submit.disabled = active;
+            submit.classList.toggle('is-busy', !!active);
+        }
+        form.classList.toggle('is-processing', active);
+    };
+
+    const handleResultPayload = (payload) => {
+        if (!payload) {
+            return;
+        }
+        setMessage(payload);
+        renderResults(payload);
+        if (Array.isArray(payload.files_skipped) && payload.files_skipped.length) {
+            payload.files_skipped.forEach((warning) => appendLog(warning, 'warning'));
+        }
+        if (payload.message_text) {
+            const type = payload.status === 'warning' ? 'warning' : payload.status === 'error' ? 'error' : 'success';
+            appendLog(payload.message_text, type);
+        }
+        const readyStatus = payload.status === 'warning' ? 'warning' : payload.status === 'error' ? 'error' : 'success';
+        appendLog(getString('ready', 'Liens de téléchargement disponibles.'), readyStatus);
+    };
+
+    if (form && settings.ajaxUrl) {
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            if (isProcessing) {
+                return;
+            }
+            toggleProcessing(true);
+            clearLog();
+            appendLog(getString('preparing', 'Préparation de la génération…'));
+            appendLog(getString('processing', 'Analyse des fichiers et création des archives…'));
+            setMessage({ status: '', message_html: '' });
+            setResultsLoading();
+
+            const formData = new FormData(form);
+            formData.set('action', 'real_media_export_generate');
+
+            fetch(settings.ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: formData,
+            })
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error('network');
+                    }
+                    return response.json();
+                })
+                .then((data) => {
+                    if (!data) {
+                        throw new Error('empty');
+                    }
+                    if (!data.success) {
+                        const payload = data.data || {};
+                        setMessage(payload);
+                        renderResults(payload);
+                        appendLog(payload.message_text || getString('error', 'Une erreur est survenue pendant la génération.'), 'error');
+                        throw new Error('server');
+                    }
+                    handleResultPayload(data.data || {});
+                })
+                .catch((error) => {
+                    if (error && error.message === 'server') {
+                        return;
+                    }
+                    renderResults({ archives: [] });
+                    const errorMessage = getString('error', 'Une erreur est survenue pendant la génération.');
+                    setMessage({ status: 'error', message_text: errorMessage });
+                    appendLog(errorMessage, 'error');
+                })
+                .finally(() => {
+                    toggleProcessing(false);
+                });
+        });
+    }
+
+    if (settings.initialResult) {
+        handleResultPayload(settings.initialResult);
+    }
+})();


### PR DESCRIPTION
## Summary
- enqueue bespoke admin assets and provide a redesigned export page with a live activity panel and animated result cards
- add AJAX-based export processing that reuses new helpers to capture archive metadata and only surface download links when generation completes
- introduce tailored CSS and JavaScript to drive the realtime log, smooth card animations, and asynchronous form submission UX

## Testing
- php -l real-media-export.php

------
https://chatgpt.com/codex/tasks/task_e_68ccf3c7932883229e1e995a78a06485